### PR TITLE
Delete anticipated release time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ The Official Website of the FRC Team 1294.
 [http://www.team1294.org](http://www.team1294.org)
 
 The website is built in PHP utilizing the bootstrap framework.
-Anticpated Release Time is Septemeber of 2014
 
 Contributions
 -------------


### PR DESCRIPTION
Like #7, the website is already live. No need for `Anticipated Release Time is September of 2014`. :stuck_out_tongue_winking_eye: 
