### PR TITLE
Update Gcal implementation to v3

### DIFF
--- a/includes/upcoming_events.php
+++ b/includes/upcoming_events.php
@@ -41,7 +41,7 @@
     $reqSettings = array( // Create an array of options used in the request to Google
         'orderBy' => 'startTime',
         'timeMin' => date("Y-m-d\TH:i:sP"), // Minimum start time for events returned. Set to current time.
-        'maxResults' => 2,
+        'maxResults' => 2, // Number of events to get
         'showDeleted' => false, // Don't return deleted elements.
         'singleEvents' => true // Return recurring events as multiple events, not one.
     );


### PR DESCRIPTION
# Fix the `Upcoming Events` Section

> (aka The _"Thanks Google!"_ Update :rage: because:
> 1. Google broke the calendar in the first place.
> 2. Google says to use `singleEvents => false` in order to have multiple recurring events. **They lied. :rage:**
>    _so pretty much, this fix could've come much sooner._

Also, you might want to take a little look for bugs, problems, and optimizations because I kind of went into _":rage:rage mode:rage:"_ after the whole `singleEvents` thing...
## Files Added/Modified
- `index.html`: Add `include` to `upcoming-events.php`.
- `upcoming-events.php`: Bulk of code
- `subtrees/google-apis`: Subtree of [`google-api-php-client`](https://github.com/google/google-api-php-client). Could be trimmed of files.
- Also, `main.js`, to change `chrome` to `Chrome` from my previous pull request #1.

Make sure to change the `$apiKey` var in `upcoming-events.php`!
