### PR TITLE
Adds registered trademark symbol to FIRST trademarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FRC-Team-1294 ![](http://img.shields.io/badge/bootstrap-3.2.0-brightgreen.svg)   ![](http://img.shields.io/badge/font%20awesome-4.3.0-brightgreen.svg)   ![](http://img.shields.io/badge/less-2.4.0-brightgreen.svg)
 =============
 
-The Official Website of the FRC Team 1294.
+The Official Website of the _FRC&#0174;_ Team 1294.
 [http://www.team1294.org](http://www.team1294.org)
 
 The website is built in PHP utilizing the bootstrap framework.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FRC-Team-1294 ![](http://img.shields.io/badge/bootstrap-3.2.0-brightgreen.svg)   ![](http://img.shields.io/badge/font%20awesome-4.3.0-brightgreen.svg)   ![](http://img.shields.io/badge/less-2.4.0-brightgreen.svg)
 =============
 
-The Official Website of the _FRC&#0174;_ Team 1294.
+The Official Website of the FRC&#0174; Team 1294.
 [http://www.team1294.org](http://www.team1294.org)
 
 The website is built in PHP utilizing the bootstrap framework.

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -22,7 +22,7 @@
                         <div class="">
                             <div class="fb-like" id="fb-like-footer" data-href="https://www.facebook.com/topgunrobotics/" data-width="450" data-layout="standard" data-action="like" data-show-faces="true" data-share="true"></div>
                             <hr>
-                            <a class="footer-links" title="Contact Us" href="/contact/">Contact Us</a> | <a class="footer-links" title="US First Robotics" href="http://usfirst.org/">US First</a> | <a class="footer-links" title="Washingotn First Robotics" href="http://firstwa.org/">First WA</a> | <a class="footer-links" href="https://plus.google.com/103733199754924235388" rel="publisher">Google+</a> | <a class="footer-links" title="Star or Fork us on GitHub" href="https://github.com/FRC-1294">GitHub</a>
+                            <a class="footer-links" title="Contact Us" href="/contact/">Contact Us</a> | <a class="footer-links" title="US FIRST Robotics" href="http://usfirst.org/">US <em>FIRST</em></a> | <a class="footer-links" title="Washington FIRST Robotics" href="http://firstwa.org/"><em>FIRST</em> WA</a> | <a class="footer-links" href="https://plus.google.com/103733199754924235388" rel="publisher">Google+</a> | <a class="footer-links" title="Star or Fork us on GitHub" href="https://github.com/FRC-1294">GitHub</a>
                         </div>
                     </div>
                 </div>

--- a/index.php
+++ b/index.php
@@ -162,7 +162,7 @@
                         </ul>
                     </div>
                     <p>
-                        Fill out our interest survery so we know what team you want to be apart of.
+                        Fill out our interest survery so we know what team you want to be a part of.
                     </p>
                     <div>
                         <ul class="no-bullets">

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
     require'includes/upper_header.php'; 
 ?>
     <title>1294 | Top Gun Robotics</title>
-    <meta name="description" content="The Official Website of the Top Gun Robotics (FRC 1294) Located In Sammmamish Washington participating in FIRST&#0174; Robotics FRC&#0174; Competitions"/>
+    <meta name="description" content="The Official Website of the Top Gun Robotics (FRC&#0174; 1294) Located In Sammmamish Washington participating in FIRST&#0174; Robotics FRC Competitions"/>
 
     <!--link rel="stylesheet" type="text/css" href="/fancybox/source/jquery.fancybox.css?v=2.1.5" media="screen" />
 	<link rel="stylesheet" type="text/css" href="/WOWSlider/engine1/style.min.css" /-->
@@ -52,7 +52,7 @@
             <img class="img-responsive" id="eastlake-logo" alt="Eastlake Logo" src="/img/Eastlake-Logo.png"/>
             <h1>We are Top Gun Robotics</h1>
             <p>
-                We are a high school <a href="http://www.usfirst.org/roboticsprograms/frc" title="First Robotics Competition"><em>FRC&#0174;</em></a> robotics team located at <a href="http://www.lwsd.org/school/ehs/Pages/default.aspx">Eastlake High School</a> in Sammamish Washington.
+                We are a high school <a href="http://www.usfirst.org/roboticsprograms/frc" title="First Robotics Competition">FRC&#0174;</a> robotics team located at <a href="http://www.lwsd.org/school/ehs/Pages/default.aspx">Eastlake High School</a> in Sammamish Washington.
                 Since 2004, we have been giving students a place where they can develop and practice their interests in science, technology, engineering, and math based fields. All thanks to our awesome mentors,   and generous sponsors.
             </p>
             <p>
@@ -143,7 +143,7 @@
                 <hr class="section-header-hr">
                 <div class="text-justified">         
                     <p>
-                        Top Gun robotics participates in <a href="http://www.usfirst.org/roboticsprograms/frc" title="First Robotics Competition"><em>FRC</em></a>, the oldest and most popular league of <a href="http://www.usfirst.org/" title="For Inspiration and Recognition of Science and Technology"><em>FIRST&#0174;</em></a> robotics.
+                        Top Gun robotics participates in <a href="http://www.usfirst.org/roboticsprograms/frc" title="First Robotics Competition">FRC</a>, the oldest and most popular league of <a href="http://www.usfirst.org/" title="For Inspiration and Recognition of Science and Technology"><em>FIRST&#0174;</em></a> robotics.
                     </p>      
                     <p>
                         Anyone is allowed to Join the Eastlake Robotics Team. It doesn't matter what school you belong to or what your experience or interests are<br>

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
     require'includes/upper_header.php'; 
 ?>
     <title>1294 | Top Gun Robotics</title>
-    <meta name="description" content="The Official Website of the Top Gun Robotics (FRC 1294) Located In Sammmamish Washington participating in FIRST Robotics FRC Competitions"/>
+    <meta name="description" content="The Official Website of the Top Gun Robotics (FRC 1294) Located In Sammmamish Washington participating in FIRST&#0174; Robotics FRC&#0174; Competitions"/>
 
     <!--link rel="stylesheet" type="text/css" href="/fancybox/source/jquery.fancybox.css?v=2.1.5" media="screen" />
 	<link rel="stylesheet" type="text/css" href="/WOWSlider/engine1/style.min.css" /-->
@@ -52,7 +52,7 @@
             <img class="img-responsive" id="eastlake-logo" alt="Eastlake Logo" src="/img/Eastlake-Logo.png"/>
             <h1>We are Top Gun Robotics</h1>
             <p>
-                We are a high school <a href="http://www.usfirst.org/roboticsprograms/frc" title="First Robotics Competition">FRC</a> robotics team located at <a href="http://www.lwsd.org/school/ehs/Pages/default.aspx">Eastlake High School</a> in Sammamish Washington.
+                We are a high school <a href="http://www.usfirst.org/roboticsprograms/frc" title="First Robotics Competition"><em>FRC&#0174;</em></a> robotics team located at <a href="http://www.lwsd.org/school/ehs/Pages/default.aspx">Eastlake High School</a> in Sammamish Washington.
                 Since 2004, we have been giving students a place where they can develop and practice their interests in science, technology, engineering, and math based fields. All thanks to our awesome mentors,   and generous sponsors.
             </p>
             <p>
@@ -143,7 +143,7 @@
                 <hr class="section-header-hr">
                 <div class="text-justified">         
                     <p>
-                        Top Gun robotics participates in <a href="http://www.usfirst.org/roboticsprograms/frc" title="First Robotics Competition">FRC</a>, the oldest and most popular league of <a href="http://www.usfirst.org/" title="For Inspiration and Recognition of Science and Technology">FIRST</a> robotics.
+                        Top Gun robotics participates in <a href="http://www.usfirst.org/roboticsprograms/frc" title="First Robotics Competition"><em>FRC</em></a>, the oldest and most popular league of <a href="http://www.usfirst.org/" title="For Inspiration and Recognition of Science and Technology"><em>FIRST&#0174;</em></a> robotics.
                     </p>      
                     <p>
                         Anyone is allowed to Join the Eastlake Robotics Team. It doesn't matter what school you belong to or what your experience or interests are<br>


### PR DESCRIPTION
According to _FIRST&#0174;_ trademark policy, "authorized users" (i.e. FRC&#0174; teams) are required to put a &#0174; symbol in front of the first instance of a _FIRST_ trademark on a page.

> The first time the trademarks appear in a headline and in copy on a page, use the &#0174; or the
&#0153; symbol, as indicated above, unless they are part of a reference to a company name (e.g.
LEGO System A/S, The LEGO Group). After the first time in any text, it’s not necessary
to repeat it.

Also, it requires the trademark _FIRST_ to be written in italics.

> The FIRST word mark is to be written in capital letters and italics, with no other
characters (e.g. periods).

This PR pretty much adds a &#0174; symbol to the README, as well as &#0174; symbols to `index.php`, as well as italicizing _FIRST_ in both `index.php` **EDIT: and in `footer.php`**. `index.php`, `footer.php`, and README were the only places I could find _FIRST_ or FRC, so there could be other places that haven't been _'properly'_ marked.

[http://www.usfirst.org/sites/default/files/uploadedFiles/About_Us/UseofUSFIRSTandLEGOGroupTrademarksandCopyrightedMaterials_FINAL.pdf](http://www.usfirst.org/sites/default/files/uploadedFiles/About_Us/UseofUSFIRSTandLEGOGroupTrademarksandCopyrightedMaterials_FINAL.pdf)
[http://www.team358.org/files/website/](http://www.team358.org/files/website/)