### PR TITLE
Contact form

### DIFF
--- a/contact/form-response.php
+++ b/contact/form-response.php
@@ -61,8 +61,8 @@
     $email = preg_replace(array('{{firstName}}', '{{lastName}}', '{{email}}', '{{subject}}', '{{message}}', '{{mailingList}}'), array($firstName, $lastName, $subject, $email, $message, $mailingList), $emailTemplate);
 
     // act
-    foreach ($sendToEmails as $email) {
-        $success = mail($email, $emailSubject, $email, "MIME-Version: 1.0\r\nContent-type:text/html;charset=UTF-8\r\nFrom: <webmaster@team1294.org>\r\n");
+    foreach ($sendToEmails as $e) {
+        $success = mail($e, $emailSubject, $email, "MIME-Version: 1.0\r\nContent-type:text/html;charset=UTF-8\r\nFrom: <webmaster@team1294.org>\r\n");
         if (!$success) error();
     }
 

--- a/contact/form-response.php
+++ b/contact/form-response.php
@@ -49,7 +49,7 @@
         else error();
     }
     $subject = parseSubjectString($data->subject);
-    $email = $data->email;
+    $submitter = $data->email;
     $message = $data->message;
     $mailingList = $data->mailingList;
     if($mailingList == true){
@@ -58,11 +58,12 @@
     	$mailingList = "No";
     }
 
-    $email = preg_replace(array('{{firstName}}', '{{lastName}}', '{{email}}', '{{subject}}', '{{message}}', '{{mailingList}}'), array($firstName, $lastName, $subject, $email, $message, $mailingList), $emailTemplate);
+    $body = preg_replace(array('{{firstName}}', '{{lastName}}', '{{email}}', '{{subject}}', '{{message}}', '{{mailingList}}'), array($firstName, $lastName, $subject, $submitter, $message, $mailingList), $emailTemplate);
+    $headers = "From: webmaster@team1294.org\r\nReply-To: ".$submitter."\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=ISO-8859-1\r\n";
 
     // act
-    foreach ($sendToEmails as $e) {
-        $success = mail($e, $emailSubject, $email, "MIME-Version: 1.0\r\nContent-type:text/html;charset=UTF-8\r\nFrom: <webmaster@team1294.org>\r\n");
+    foreach ($sendToEmails as $email) {
+        $success = mail($email, $emailSubject, $body, $headers);
         if (!$success) error();
     }
 

--- a/contact/form-response.php
+++ b/contact/form-response.php
@@ -9,7 +9,7 @@
 	/* START CONFIG BLOCK */
 	$sendToEmails = array("austin.jenchi@team1294.org");  // an array of emails to send to ("email1@email.com", "email2@email.com")
 	$emailSubject = "1294 Form Response";
-	$emailTemplate = "<h1>1294 Contact Form</h1>\r\n<p>A new response has been sent via the 1294 contact form.</p>\r\n<hr>\r\n<p><strong>Name:</strong> {firstName} {lastName}</p>\r\n<p><strong>Email:</strong> {email}</p>\r\n<p><strong>Subject:</strong> {subject}</p>\r\n<p><strong>Message:</strong> {message}</p>\r\n<p><strong>Mailing List?:</strong> {mailingList}</p>";
+	$emailTemplate = "<h1>1294 Contact Form</h1>\r\n<p>A new response has been sent via the 1294 contact form.</p>\r\n<hr>\r\n<p><strong>Name:</strong> {{firstName}} {{lastName}}</p>\r\n<p><strong>Email:</strong> {{email}}</p>\r\n<p><strong>Subject:</strong> {{subject}}</p>\r\n<p><strong>Message:</strong> {{message}}</p>\r\n<p><strong>Mailing List?:</strong> {{mailingList}}</p>";
 	/* END CONFIG BLOCK */
 
     header('Content-Type: text/plain');
@@ -49,7 +49,7 @@
     	$mailingList = "No";
     }
 
-    $body = preg_replace(array('{firstName}', '{lastName}', '{email}', '{subject}', '{message}', '{mailingList}'), array($firstName, $lastName, $submitter, $subject, $message, $mailingList), $emailTemplate);
+    $body = preg_replace(array('/{{firstName}}/', '/{{lastName}}/', '/{{email}}/', '/{{subject}}/', '/{{message}}/', '/{{mailingList}}/'), array($firstName, $lastName, $submitter, $subject, $message, $mailingList), $emailTemplate);
     $headers = "From: webmaster@team1294.org\r\nReply-To: ".$submitter."\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=ISO-8859-1\r\n";
 
     // act

--- a/contact/form-response.php
+++ b/contact/form-response.php
@@ -9,16 +9,7 @@
 	/* START CONFIG BLOCK */
 	$sendToEmails = array("austin.jenchi@team1294.org");  // an array of emails to send to ("email1@email.com", "email2@email.com")
 	$emailSubject = "1294 Form Response";
-	$emailTemplate = "
-	<h1>1294 Contact Form</h1>
-	<p>A new response has been sent via the 1294 contact form.</p>
-	<hr>
-	<p><strong>Name:</strong> {{firstName}} {{lastName}}</p>
-	<p><strong>Email:</strong> {{email}}</p>
-	<p><strong>Subject:</strong> {{subject}}</p>
-	<p><strong>Message:</strong> {{message}}</p>
-	<p><strong>Mailing List?:</strong> {{mailingList}}</p>
-	";
+	$emailTemplate = "<h1>1294 Contact Form</h1>\r\n<p>A new response has been sent via the 1294 contact form.</p>\r\n<hr>\r\n<p><strong>Name:</strong> {{firstName}} {{lastName}}</p>\r\n<p><strong>Email:</strong> {{email}}</p>\r\n<p><strong>Subject:</strong> {{subject}}</p>\r\n<p><strong>Message:</strong> {{message}}</p>\r\n<p><strong>Mailing List?:</strong> {{mailingList}}</p>";
 	/* END CONFIG BLOCK */
 
     header('Content-Type: text/plain');

--- a/contact/form-response.php
+++ b/contact/form-response.php
@@ -62,7 +62,8 @@
 
     // act
     foreach ($sendToEmails as $email) {
-        mail($email, $emailSubject, $email, "MIME-Version: 1.0\r\nContent-type:text/html;charset=UTF-8\r\nFrom: <webmaster@team1294.org>\r\n");
+        $success = mail($email, $emailSubject, $email, "MIME-Version: 1.0\r\nContent-type:text/html;charset=UTF-8\r\nFrom: <webmaster@team1294.org>\r\n");
+        if (!$success) error();
     }
 
     // respond

--- a/contact/form-response.php
+++ b/contact/form-response.php
@@ -9,7 +9,7 @@
 	/* START CONFIG BLOCK */
 	$sendToEmails = array("austin.jenchi@team1294.org");  // an array of emails to send to ("email1@email.com", "email2@email.com")
 	$emailSubject = "1294 Form Response";
-	$emailTemplate = "<h1>1294 Contact Form</h1>\r\n<p>A new response has been sent via the 1294 contact form.</p>\r\n<hr>\r\n<p><strong>Name:</strong> {{firstName}} {{lastName}}</p>\r\n<p><strong>Email:</strong> {{email}}</p>\r\n<p><strong>Subject:</strong> {{subject}}</p>\r\n<p><strong>Message:</strong> {{message}}</p>\r\n<p><strong>Mailing List?:</strong> {{mailingList}}</p>";
+	$emailTemplate = "<h1>1294 Contact Form</h1>\r\n<p>A new response has been sent via the 1294 contact form.</p>\r\n<hr>\r\n<p><strong>Name:</strong> {firstName} {lastName}</p>\r\n<p><strong>Email:</strong> {email}</p>\r\n<p><strong>Subject:</strong> {subject}</p>\r\n<p><strong>Message:</strong> {message}</p>\r\n<p><strong>Mailing List?:</strong> {mailingList}</p>";
 	/* END CONFIG BLOCK */
 
     header('Content-Type: text/plain');
@@ -49,7 +49,7 @@
     	$mailingList = "No";
     }
 
-    $body = preg_replace(array('{{firstName}}', '{{lastName}}', '{{email}}', '{{subject}}', '{{message}}', '{{mailingList}}'), array($firstName, $lastName, $subject, $submitter, $message, $mailingList), $emailTemplate);
+    $body = preg_replace(array('{firstName}', '{lastName}', '{email}', '{subject}', '{message}', '{mailingList}'), array($firstName, $lastName, $submitter, $subject, $message, $mailingList), $emailTemplate);
     $headers = "From: webmaster@team1294.org\r\nReply-To: ".$submitter."\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=ISO-8859-1\r\n";
 
     // act

--- a/contact/form-response.php
+++ b/contact/form-response.php
@@ -8,7 +8,7 @@
 
 	/* START CONFIG BLOCK */
 	$sendToEmails = array("austin.jenchi@team1294.org");  // an array of emails to send to ("email1@email.com", "email2@email.com")
-	$emailSubject = "1294 Form Response";
+	$emailSubject = "1294 Form Response - ".date('m/d/Y h:i:s a', time());
 	$emailTemplate = "<h1>1294 Contact Form</h1>\r\n<p>A new response has been sent via the 1294 contact form.</p>\r\n<hr>\r\n<p><strong>Name:</strong> {{firstName}} {{lastName}}</p>\r\n<p><strong>Email:</strong> {{email}}</p>\r\n<p><strong>Subject:</strong> {{subject}}</p>\r\n<p><strong>Message:</strong> {{message}}</p>\r\n<p><strong>Mailing List?:</strong> {{mailingList}}</p>";
 	/* END CONFIG BLOCK */
 

--- a/contact/form-response.php
+++ b/contact/form-response.php
@@ -7,7 +7,7 @@
 	 */
 
 	/* START CONFIG BLOCK */
-	$sendToEmails = array("contact-us@team1294.org");  // an array of emails to send to ("email1@email.com", "email2@email.com")
+	$sendToEmails = array("austin.jenchi@team1294.org");  // an array of emails to send to ("email1@email.com", "email2@email.com")
 	$emailSubject = "1294 Form Response";
 	$emailTemplate = "
 	<h1>1294 Contact Form</h1>

--- a/contact/index.php
+++ b/contact/index.php
@@ -100,7 +100,7 @@
                             <label for="email" class="col-lg-2 control-label">Email</label>
                             <div class="col-lg-10">
                                 <!--input type="email" class="form-control" id="inputEmail" placeholder="Your Email" data-bv-emailaddress-message="try again" required />-->
-                                <input type="email" class="form-control" name="email" placeholder="Your Email Address" required/>
+                                <input type="email" class="form-control" id="email" name="email" placeholder="Your Email Address" required/>
                             </div>
                         </div>
                         <div class="form-group">


### PR DESCRIPTION
Fixes #22.

<hr>

Dreamhost (appears to have) changed their policies on non-Dreamhost hosted emails and the PHP `mail()` function, allowing us to send emails from PHP scripts on the server.