### PR TITLE
Reduce cache expiration for calendar block to 1 hour

### DIFF
--- a/includes/upcoming_events.php
+++ b/includes/upcoming_events.php
@@ -180,7 +180,6 @@
             $temp = null;
             preg_match("/Eastlake High School/", $location, $temp); // regex for a count of ocurances of "Eastlake High School" in $location
             if(count($temp) > 0){
-                $location = 'Eastlake High School<br>';
                 $mapLink = '<a rel="nofollow" href="https://maps.google.com/?q='.urlencode("Eastlake High School, 400 228th Ave NE, Sammamish, WA, United States").'" class="btn btn-primary btn-xs">Map It</a>';
                 $location = 'Eastlake High School<br>';
             }else if(!$location){

--- a/includes/upcoming_events.php
+++ b/includes/upcoming_events.php
@@ -72,7 +72,7 @@
     function checkCacheFileDate(){
         global $cacheFilePath;
         $timedif = @(time() - filemtime($cacheFilePath));
-        return file_exists($cacheFilePath) && $timedif < 43200 /* 12 hours in seconds */;
+        return file_exists($cacheFilePath) && $timedif < 3600; // 1 hour in seconds
     }
 
     function getOnlineData(){


### PR DESCRIPTION
Resolves #90 by reducing the calendar's cache to 1 hour from 12. This allows details to be updated much more often and quicker without needing to FTP into the server and manually deleting the file. There are other solutions to this, but this is easy enough to do, and it's unlikely that we'll hit the Google Calendar API's request limit.